### PR TITLE
Corrects Helper Methods with parameter alias

### DIFF
--- a/actions/leadlovers_upsert_lead.json
+++ b/actions/leadlovers_upsert_lead.json
@@ -151,7 +151,7 @@
             "visible": true,
             "advanced": false,
             "field_type": "dropdown",
-            "data_type": "string",
+            "data_type": "integer",
             "list": {
               "type": "remote",
               "helper_method": "email_sequence_code_list"
@@ -176,7 +176,7 @@
             "visible": true,
             "advanced": false,
             "field_type": "dropdown",
-            "data_type": "string",
+            "data_type": "integer",
             "list": {
               "type": "remote",
               "helper_method": "sequence_level_code_list"

--- a/helper_methods/leadlovers_email_sequence_code_list.json
+++ b/helper_methods/leadlovers_email_sequence_code_list.json
@@ -3,7 +3,7 @@
   "helper_method_key": "email_sequence_code_list",
   "requests": [
   	{
-      "method_name": "/emailsequences?token={token}&MachineCode={MachineCode}",
+      "method_name": "/emailsequences",
       "response_field": "Items",
       "params": { "MachineCode": "{MachineCode}" },
       "mapping": {

--- a/helper_methods/leadlovers_machine_code_list.json
+++ b/helper_methods/leadlovers_machine_code_list.json
@@ -3,7 +3,7 @@
   "helper_method_key": "machine_code_list",
   "requests": [
   	{
-      "method_name": "/machines?token={token}",
+      "method_name": "/machines",
       "response_field": "Items",
       "params": {},
       "mapping": {

--- a/helper_methods/leadlovers_sequence_level_code_list.json
+++ b/helper_methods/leadlovers_sequence_level_code_list.json
@@ -3,9 +3,9 @@
   "helper_method_key": "sequence_level_code_list",
   "requests": [
   	{
-      "method_name": "/levels?token={token}&MachineCode={MachineCode}&SequenceCode={SequenceCode}",
+      "method_name": "/levels",
       "response_field": "Items",
-      "params": { "MachineCode": "{MachineCode}", "SequenceCode": "{SequenceCode}" },
+      "params": { "MachineCode": "{MachineCode}", "EmailSequenceCode": "{EmailSequenceCode}" },
       "mapping": {
         "label": {
           "fields": ["Subject"]

--- a/helper_methods/leadlovers_sequence_level_code_list.json
+++ b/helper_methods/leadlovers_sequence_level_code_list.json
@@ -5,7 +5,8 @@
   	{
       "method_name": "/levels",
       "response_field": "Items",
-      "params": { "MachineCode": "{MachineCode}", "EmailSequenceCode": "{EmailSequenceCode}" },
+      "params": { "MachineCode": "{MachineCode}" },
+      "extra_params": [{ "key": "EmailSequenceCode", "alias": "SequenceCode" }],
       "mapping": {
         "label": {
           "fields": ["Subject"]


### PR DESCRIPTION
This PR corrects the helper method `leadlovers_sequence_level_code_list` to account for the inconsistency in parameter naming in the Leadlovers API.

Other changes are:

1. Changes attribute types (EmailSequenceCode and SequenceLevelCode) to integer
2. Removes unnecessary query string arguments on helper_method endpoint uri
