### PR TITLE
Adds support for request body payload to webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,77 @@
 # leadlovers
 leadlovers app on Pluga
+
+## Triggers
+
+### new_lead (Rest Hook)
+
+* Cadastro do hook:
+
+Url:  http://llapi.leadlovers.com/webapi/RestHook?token={Token do Usuário}&applicationName=Pluga
+Método: POST
+
+Exemplo de objeto esperado:
+
+```
+{  
+   "Target_url":"https://mydomain.com/hooks/foo/bar/",
+   "Event":"new_lead_event"
+}
+```
+
+Exemplo de resposta:
+
+Status: 200
+
+```
+{  
+   "StatusCode":200,
+   "Message":"Sucesso ao inserir hook."
+}
+```
+
+* Remoção do hook:
+
+Url:  http://llapi.leadlovers.com/webapi/RestHook?token={Token do Usuário}&applicationName=Pluga
+Método: DELETE
+
+Exemplo de objeto esperado:
+
+```
+{  
+   "Subscription_url":"https://mydomain.com/hooks/foo/bar/",
+   "Event":"new_lead_event"
+}
+```
+
+Exemplo de resposta:
+
+Status: 200
+
+```
+{  
+   "StatusCode":200,
+   "Message":"Hook removido com sucesso."
+} 
+```
+
+* Payload recebido pelo hook
+
+```
+{
+  "Id":127809975,
+  "Email":"testedata@pluga.co",
+  "CreatedDate":"0001-01-01T02:00:00Z",
+  "FixedFieldsEntity":{
+    "Name":"Teste",
+    "Phone":"315555555",
+    "BirthDate":"10/01/1990 00:00:00",
+    "Company":"Teste",
+    "City":"Belo Horizonte",
+    "State":"Minas Gerais"
+  },
+  "DynamicFields":[]
+}
+```
+
+Copyright Pluga (c) 2018

--- a/triggers/leadlovers_new_lead_trigger.json
+++ b/triggers/leadlovers_new_lead_trigger.json
@@ -83,6 +83,9 @@
         "method_name": "/RestHook?token={token}&applicationName=Pluga",
         "params":{
           "Id": "{id}"
+        },
+        "body":{
+          "key": "Id"
         }
       },
       "meta_params": {

--- a/triggers/leadlovers_new_lead_trigger.json
+++ b/triggers/leadlovers_new_lead_trigger.json
@@ -75,7 +75,6 @@
         "verb": "POST",
         "method_name": "/RestHook?token={token}&applicationName=Pluga",
         "params": {
-          "Target_url": "{O que colocar aqui?}",
           "Event": "new_lead_event"
         }
       },
@@ -83,9 +82,12 @@
         "verb":"DELETE",
         "method_name": "/RestHook?token={token}&applicationName=Pluga",
         "params":{
-          "Subscription_url": "{O que colocar aqui?}",
+          "Subscription_url": "{url}",
           "Event": "new_lead_event"
         }
+      },
+      "meta_params": {
+        "webhook_url": "Target_url"
       }
     },
     "idempotent":[

--- a/triggers/leadlovers_new_lead_trigger.json
+++ b/triggers/leadlovers_new_lead_trigger.json
@@ -1,0 +1,95 @@
+{
+  "name":{
+    "pt_BR":"Lead Criado",
+    "en":"Lead created"
+  },
+  "trigger_key":"new_lead",
+  "description":{
+    "pt_BR":"Quando um lead for criado.",
+    "en":"When a lead is created."
+  },
+  "trigger_fields":{
+    "type":"local",
+    "fields":[
+      {
+        "key":"Id",
+        "name":"ID",
+        "description":"ID.",
+        "field_type":"integer"
+      },
+      {
+        "key":"Email",
+        "name":"Email",
+        "description":"Email.",
+        "field_type":"string"
+      },
+      {
+        "key":"CreatedDate",
+        "name":"Data/Hora",
+        "description":"Data/Hora.",
+        "field_type":"date_time"
+      },
+      {
+        "key":"FixedFieldsEntity.Name",
+        "name":"Nomes do Lead",
+        "description":"Nomes do lead",
+        "field_type":"string"
+      },
+      {
+        "key":"FixedFieldsEntity.Phone",
+        "name":"Telefone de Contato do Lead",
+        "description":"Telefone de contato do lead",
+        "field_type":"string"
+      },
+      {
+        "key":"FixedFieldsEntity.BirthDate",
+        "name":"Data de Nascimento do Lead",
+        "description":"Data de nascimento do lead.",
+        "field_type":"date_time"
+      },
+      {
+        "key":"FixedFieldsEntity.Company",
+        "name":"Empresa do Lead",
+        "description":"Empresa do lead",
+        "field_type":"string"
+      },
+      {
+        "key":"FixedFieldsEntity.City",
+        "name":"Cidade do Lead",
+        "description":"Cidade do lead",
+        "field_type":"string"
+      },
+      {
+        "key":"FixedFieldsEntity.State",
+        "name":"Estado (UF) do Lead",
+        "description":"Estado (UF) do lead",
+        "field_type":"string"
+      }
+    ]
+  },
+  "trigger_type":"rest_hook",
+  "webhook":{
+    "message_type":"object",
+    "rest_hook_config":{
+      "create": {
+        "verb": "POST",
+        "method_name": "/RestHook?token={token}&applicationName=Pluga",
+        "params": {
+          "Target_url": "{O que colocar aqui?}",
+          "Event": "new_lead_event"
+        }
+      },
+      "delete":{
+        "verb":"DELETE",
+        "method_name": "/RestHook?token={token}&applicationName=Pluga",
+        "params":{
+          "Subscription_url": "{O que colocar aqui?}",
+          "Event": "new_lead_event"
+        }
+      }
+    },
+    "idempotent":[
+      {"type":"body", "field":"Id"}
+    ]
+  }
+}

--- a/triggers/leadlovers_new_lead_trigger.json
+++ b/triggers/leadlovers_new_lead_trigger.json
@@ -82,12 +82,12 @@
         "verb":"DELETE",
         "method_name": "/RestHook?token={token}&applicationName=Pluga",
         "params":{
-          "Subscription_url": "{url}",
-          "Event": "new_lead_event"
+          "Id": "{id}"
         }
       },
       "meta_params": {
-        "webhook_url": "Target_url"
+        "webhook_url": "Target_url",
+        "webhook_id": "Id"
       }
     },
     "idempotent":[


### PR DESCRIPTION
For hooks that require passing of information on the body of the request you can add

```
"body": {
  "key": "ExpectedIdVariableName"
}
```

To the specific action of the rest_hook_config. For example, leadlovers expects the id of a given hook to be passed in the body of a DELETE request as such:

```
{
  "Id": 123
}
```

Pluga-API will construct this body using the task's webhook_id which is stored from the hook's creation.